### PR TITLE
Proper error handling while reading the pom file.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,13 +11,19 @@ var pomPath = [cwd, 'pom.xml'].join('/');
 if(args.length != 3) {
   console.log('Wrong usage, you must inform the artifact, example "easymaven gson"');
 } else {
-  fs.exists(pomPath, function(exists) {
-   if(exists) {
-     var artifact = args[2]
-     easymaven(pomPath, artifact);
-   } else {
-     console.log('This is not a maven project');
-   }
+  fs.open(pomPath, "rw", function(error) {
+    if(!error) {
+      var artifact = args[2];
+      easymaven(pomPath, artifact);
+    } else {
+      switch(error.code) {
+        case "EACCES":
+          console.error("Can't open", pomPath);
+          break;
+        default:
+          console.error('This is not a Maven project')
+      }
+    }
   });
 }
 

--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ var pomPath = [cwd, 'pom.xml'].join('/');
 if(args.length != 3) {
   console.log('Wrong usage, you must inform the artifact, example "easymaven gson"');
 } else {
-  fs.open(pomPath, "rw", function(error) {
+  fs.open(pomPath, "r+", function(error) {
     if(!error) {
       var artifact = args[2];
       easymaven(pomPath, artifact);


### PR DESCRIPTION
It is nice to inform the user when there are not enough permission to read and write to the pom file. Also, `fs.exists` is deprecated.
